### PR TITLE
Replace slashes in image name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 test
+urls
+articles

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func main() {
 		}
 
 		articleSafeName := strings.ReplaceAll(strings.ToLower(article.Title), " ", "_")
+		articleSafeName = strings.ReplaceAll(articleSafeName, "/", "_")
 		epubPath := filepath.Join(outputDir, articleSafeName+".epub")
 
 		if fileExists(epubPath) {


### PR DESCRIPTION
This commit makes it so slashes in image names are replaced with an underscore. This prevent issues when saving the image.

Closes #2