### PR TITLE
Handle missing image and too short content

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,10 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to parse url: %s\n%v\n", url, err)
 			continue
+		} else if len(article.Content) < 200 {
+			log.Print(colorWarning + "Downloaded content is shorter than 200 characters so the page probably was not parsed properly:" + colorReset)
+			log.Print(colorWarning + "URL: " + url + colorReset)
+			continue
 		}
 
 		articleSafeName := strings.ReplaceAll(strings.ToLower(article.Title), " ", "_")

--- a/main.go
+++ b/main.go
@@ -98,9 +98,11 @@ func main() {
 		}
 
 		coverImagePath := filepath.Join(tempDir, articleSafeName+".jpg")
-		err = downloadFile(article.Image, coverImagePath)
-		if err != nil {
-			log.Fatal(err)
+		if article.Image != "" {
+			err = downloadFile(article.Image, coverImagePath)
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 
 		htmlPath := filepath.Join(tempDir, articleSafeName+".html")
@@ -129,6 +131,25 @@ func main() {
 			coverImagePath,
 			htmlPath,
 		)
+
+		if len(article.Image) == 0 {
+			cmd = exec.Command(
+				"pandoc",
+				"-f",
+				"html",
+				"-t",
+				"epub",
+				"-o",
+				epubPath,
+				"--metadata",
+				fmt.Sprintf("title: %s", article.Title),
+				"--metadata",
+				fmt.Sprintf("author: %s", article.Byline),
+				"--metadata",
+				fmt.Sprintf("subject: %s", articleTag),
+				htmlPath,
+			)
+		}
 
 		err = cmd.Run()
 		if err != nil {


### PR DESCRIPTION
This PR fixes two bugs:

- Fix crashing when no image available
- Prevent downloading error pages

This closes #1
